### PR TITLE
Change event type to respawn and add a minimum balance config option

### DIFF
--- a/src/main/java/link/harryw/deathpenalty/DeathPenalty.java
+++ b/src/main/java/link/harryw/deathpenalty/DeathPenalty.java
@@ -1,7 +1,7 @@
 package link.harryw.deathpenalty;
 
 import link.harryw.deathpenalty.commands.DPReload;
-import link.harryw.deathpenalty.events.DeathEvent;
+import link.harryw.deathpenalty.events.RespawnEvent;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -22,7 +22,7 @@ public final class DeathPenalty extends JavaPlugin {
             return;
         }
         saveDefaultConfig();
-        getServer().getPluginManager().registerEvents(new DeathEvent(this), this);
+        getServer().getPluginManager().registerEvents(new RespawnEvent(this), this);
         this.getCommand("dpreload").setExecutor(new DPReload(this));
     }
 

--- a/src/main/java/link/harryw/deathpenalty/events/RespawnEvent.java
+++ b/src/main/java/link/harryw/deathpenalty/events/RespawnEvent.java
@@ -7,21 +7,21 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 
-public class DeathEvent implements Listener {
+public class RespawnEvent implements Listener {
 
     private final Economy econ;
     private final DeathPenalty plugin;
 
-    public DeathEvent(DeathPenalty plugin) {
+    public RespawnEvent(DeathPenalty plugin) {
         this.plugin = plugin;
         this.econ = DeathPenalty.econ;
     }
 
     @EventHandler
-    public void deathEvent(PlayerDeathEvent e) {
-        Player p = e.getEntity().getPlayer();
+    public void respawnEvent(PlayerRespawnEvent e) {
+        Player p = e.getPlayer();
         FileConfiguration config = plugin.getConfig();
 
         double currentBalance = econ.getBalance(p);
@@ -29,7 +29,7 @@ public class DeathEvent implements Listener {
 
         if(config.getString("lossType").equalsIgnoreCase("percentage")) {
             int percentageAmount = config.getInt("percentageLost");
-            withdrawAmount = currentBalance*(percentageAmount/100.0f);
+            withdrawAmount = currentBalance*(percentageAmount / 100.0f);
         } else if(config.getString("lossType").equalsIgnoreCase("fixed")) {
             withdrawAmount = config.getInt("amountLost");
         }

--- a/src/main/java/link/harryw/deathpenalty/events/RespawnEvent.java
+++ b/src/main/java/link/harryw/deathpenalty/events/RespawnEvent.java
@@ -27,15 +27,17 @@ public class RespawnEvent implements Listener {
         double currentBalance = econ.getBalance(p);
         double withdrawAmount = 0.0f;
 
-        if(config.getString("lossType").equalsIgnoreCase("percentage")) {
-            int percentageAmount = config.getInt("percentageLost");
-            withdrawAmount = currentBalance*(percentageAmount / 100.0f);
-        } else if(config.getString("lossType").equalsIgnoreCase("fixed")) {
-            withdrawAmount = config.getInt("amountLost");
+        if(currentBalance >= config.getInt("minimumBalance")) {
+            if(config.getString("lossType").equalsIgnoreCase("percentage")) {
+                int percentageAmount = config.getInt("percentageLost");
+                withdrawAmount = currentBalance * (percentageAmount / 100.0f);
+            } else if(config.getString("lossType").equalsIgnoreCase("fixed")) {
+                withdrawAmount = config.getInt("amountLost");
+            }
+
+            econ.withdrawPlayer(p, withdrawAmount);
+
+            p.sendMessage(ChatColor.translateAlternateColorCodes('&', config.getString("prefix")) + ChatColor.translateAlternateColorCodes('&', config.getString("deathMessage")).replace("%amount%", String.valueOf((int) withdrawAmount)));
         }
-
-        econ.withdrawPlayer(p, withdrawAmount);
-
-        p.sendMessage(ChatColor.translateAlternateColorCodes('&', config.getString("prefix")) + ChatColor.translateAlternateColorCodes('&', config.getString("deathMessage")).replace("%amount%", String.valueOf((int) withdrawAmount)));
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,10 +6,12 @@
 # Valid options are "percentage" and "fixed"
 lossType: "percentage"
 
-# Only used if lossType is percentage
+# The percentage of total money players will lose on death
+# Only used if lossType is set to "percentage"
 percentageLost: 50
 
-# Only used if lossType is fixed
+# The fixed amount of money players will lose on death
+# Only used if lossType is set to "fixed"
 amountLost: 100
 
 # Messages

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,11 @@ percentageLost: 50
 # Only used if lossType is set to "fixed"
 amountLost: 100
 
+# The minimum balance player has to have in order to lose money on death
+# If you want the penalty to apply on death regardless of the player's balance,
+# setting this to 0 will effectively mean that this option is disabled
+minimumBalance: 1000
+
 # Messages
 prefix: "&6[&c&lDP&6]&r "
 reloadConfig: "&bThe config has been reloaded."


### PR DESCRIPTION
- Changes the event type from `PlayerDeathEvent` to `PlayerRespawnEvent`. While this has no functionality changes, it allows for the chat message to be displayed once the player actually respawns - should be more convenient?
- Adds a new `minimumBalance` config option. I found it weird that the plugin attempted to take money from the player even though they were out of money. This option allows to define the minimum amount of money players need to have in order for the plugin to take money from them on death.